### PR TITLE
fix: line breaks are ignored when facts are displayed

### DIFF
--- a/src/main/webapp/resources/css/custom.css
+++ b/src/main/webapp/resources/css/custom.css
@@ -418,6 +418,7 @@ textarea.form-control {
     line-height: 1.65;
     color: var(--cream);
     font-style: italic;
+    white-space: pre-wrap;
 }
 .evidence-meta {
     margin-top: 32px;


### PR DESCRIPTION
see #3 

Fixed with `white-space: pre-wrap` to properly handle line breaks on the frontend since they are already correctly stored and logged on the server and just not displayed correctly.